### PR TITLE
修复七牛上传图片非华东地区会失败的 bug

### DIFF
--- a/model/Upload.go
+++ b/model/Upload.go
@@ -22,7 +22,7 @@ func UpLoadFile(file multipart.File, fileSize int64) (string, int) {
 	upToken := putPolicy.UploadToken(mac)
 
 	cfg := storage.Config{
-		Zone:          &storage.ZoneHuadong,
+		// Zone:          &storage.ZoneHuadong, // 自动获取地区，不另外指定
 		UseCdnDomains: false,
 		UseHTTPS:      false,
 	}


### PR DESCRIPTION
上传图片的时候失败，打印 err 发现报 `incorrect region, please use up-z2.qiniup.com`。

查了一下是说地域不一致的原因，然后看了下 [SDK 文档](https://developer.qiniu.com/qvs/6924/qvs-go-sdk) 里写的是 Zone 可以为空，注释掉发现可以正常上传了。

![image](https://user-images.githubusercontent.com/24295778/126058600-1a2f987b-22dc-4ffc-9e79-fde8421ee797.png)

PS. 虽然 SDK 文档里写的是「默认为 z0 华东」，但是我注释后华南和北美都成功了，不知道为啥，就感觉为空的话就采用自动获取的方式。